### PR TITLE
Make axios injectable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# Axios client adapter for smartlyio/oats
+
+See [smartlyio/oats](https://github.com/smartlyio/oats)
+
+This adapter provides two ways to bind the generated client definitions
+
+```
+import * as adapter from '@smartlyio/oats-axios-adapter
+
+// bind the default axios instance
+adapter.bind(definitions);
+
+// provide your own axios instance
+adapter.withAxios(someAxiosInstance)(definitions);
+```
+

--- a/index.ts
+++ b/index.ts
@@ -77,7 +77,6 @@ export const bind: runtime.client.ClientAdapter = async (
   const data = toRequestData(arg.body);
   const url = server + arg.path;
   const headers = { ...arg.headers, ...(data instanceof FormData ? data.getHeaders() : {}) };
-
   const response = await axios.request({
     method: arg.method,
     headers,

--- a/index.ts
+++ b/index.ts
@@ -1,7 +1,7 @@
 import * as runtime from '@smartlyio/oats-runtime';
 import * as FormData from 'form-data';
 import * as assert from 'assert';
-import axios, { AxiosResponse } from 'axios';
+import axios, { AxiosInstance, AxiosResponse } from 'axios';
 
 function toRequestData(data: runtime.server.RequestBody<any> | undefined) {
   if (data == null) {
@@ -33,7 +33,8 @@ function axiosToJson(data: any) {
 }
 
 export const bind: runtime.client.ClientAdapter = async (
-  arg: runtime.server.EndpointArg<any, any, any, any>
+  arg: runtime.server.EndpointArg<any, any, any, any>,
+  client?: AxiosInstance
 ): Promise<runtime.server.Response<any, any, any, Record<string, any>>> => {
   if (arg.servers.length !== 1) {
     return assert.fail('cannot decide which server to use from ' + arg.servers.join(', '));
@@ -43,7 +44,8 @@ export const bind: runtime.client.ClientAdapter = async (
   const data = toRequestData(arg.body);
   const url = server + arg.path;
   const headers = { ...arg.headers, ...(data instanceof FormData ? data.getHeaders() : {}) };
-  const response = await axios.request({
+  const axiosClient = client ? client : axios;
+  const response = await axiosClient.request({
     method: arg.method,
     headers,
     url,

--- a/index.ts
+++ b/index.ts
@@ -1,7 +1,7 @@
 import * as runtime from '@smartlyio/oats-runtime';
 import * as FormData from 'form-data';
 import * as assert from 'assert';
-import axios, { AxiosInstance, AxiosResponse } from 'axios';
+import globalAxios, { AxiosInstance, AxiosResponse } from 'axios';
 
 function toRequestData(data: runtime.server.RequestBody<any> | undefined) {
   if (data == null) {
@@ -32,9 +32,9 @@ function axiosToJson(data: any) {
   return data;
 }
 
-export const bind: runtime.client.ClientAdapter = withAxios(axios);
+export const bind: runtime.client.ClientAdapter = withAxios(globalAxios);
 
-export function withAxios(client: AxiosInstance): runtime.client.ClientAdapter {
+export function withAxios(axiosInstance: AxiosInstance): runtime.client.ClientAdapter {
   return async (
     arg: runtime.server.EndpointArg<any, any, any, any>
   ): Promise<runtime.server.Response<any, any, any, Record<string, any>>> => {
@@ -46,7 +46,7 @@ export function withAxios(client: AxiosInstance): runtime.client.ClientAdapter {
     const data = toRequestData(arg.body);
     const url = server + arg.path;
     const headers = { ...arg.headers, ...(data instanceof FormData ? data.getHeaders() : {}) };
-    const response = await axios.request({
+    const response = await axiosInstance.request({
       method: arg.method,
       headers,
       url,


### PR DESCRIPTION
Make axios injectable to support use cases where you want to have your own instance. I tested this with my API client against nock. With that test at least the 'baseURL' and default headers seem to work just fine.